### PR TITLE
🐛チャット投稿後にリアルタイム更新されない問題を解決

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,8 +7,9 @@ class MessagesController < ApplicationController
 
     ActionCable.server.broadcast(
       "chat_room_#{@message.chat_room_id}",
-      { content: render_message(@message) }
-    )    
+      { message: render_message(@message) }
+    )
+    head :ok
   end
 
   private

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,4 +2,4 @@
 import "@hotwired/turbo-rails";
 import "controllers";
 import "stripe_payment";
-import "./channels"
+import "channels"

--- a/app/javascript/channels/chat_room_channel.js
+++ b/app/javascript/channels/chat_room_channel.js
@@ -1,4 +1,4 @@
-import consumer from "./consumer"
+import consumer from "channels/consumer"
 
 document.addEventListener("DOMContentLoaded", () => {
   const element = document.getElementById("chat-room");

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,4 @@
+// app/javascript/channels/consumer.js
+import { createConsumer } from "@rails/actioncable"
+
+export default createConsumer()

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,0 +1,4 @@
+// app/javascript/channels/index.js
+
+import "channels/consumer"
+import "channels/chat_room_channel"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,6 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@stripe/stripe-js", to: "@stripe--stripe-js.js" # @7.3.0
 pin "stripe_payment"
 pin "@rails/ujs", to: "rails-ujs.js"
+pin "@rails/actioncable", to: "actioncable.esm.js"
+pin "channels", to: "channels/index.js"
+pin_all_from "app/javascript/channels", under: "channels"


### PR DESCRIPTION
以下の問題に対応しました。

- [x] chat_room_channel.js が読み込まれていない問題を解決
- [x] Ruby と JS でメッセージのハッシュキーを統一
  * JS が `message` を想定しているが Ruby では `content` になっていた
- [x] `bin/rails generate channel chat_room` を実行
  以下のファイルは特に何も処理していないように見えますが必要でした
  * app/channels/application_cable/channel.rb
  * app/channels/application_cable/connection.rb
